### PR TITLE
Return std::optional in RobotDriver::get_error()

### DIFF
--- a/include/robot_interfaces_bolt/bolthumanoid_driver.hpp
+++ b/include/robot_interfaces_bolt/bolthumanoid_driver.hpp
@@ -31,7 +31,7 @@ public:
     void initialize() override;
     Action apply_action(const Action &desired_action) override;
     Observation get_latest_observation() override;
-    std::string get_error() override;
+    std::optional<std::string> get_error() override;
     void shutdown() override;
 
 private:
@@ -55,7 +55,7 @@ public:
     void initialize() override;
     Action apply_action(const Action &desired_action) override;
     Observation get_latest_observation() override;
-    std::string get_error() override;
+    std::optional<std::string> get_error() override;
     void shutdown() override;
 
 private:

--- a/include/robot_interfaces_bolt/bolthumanoid_pybullet_driver.hpp
+++ b/include/robot_interfaces_bolt/bolthumanoid_pybullet_driver.hpp
@@ -85,7 +85,7 @@ public:
     BoltHumanoidObservation get_latest_observation() override;
     BoltHumanoidAction apply_action(
         const BoltHumanoidAction &desired_action) override;
-    std::string get_error() override;
+    std::optional<std::string> get_error() override;
     void shutdown() override;
 
     //! Get the bullet environment instance for direct access to the simulation.

--- a/src/bolthumanoid_driver.cpp
+++ b/src/bolthumanoid_driver.cpp
@@ -126,18 +126,18 @@ BoltHumanoidDriver::Observation BoltHumanoidDriver::get_latest_observation()
     return obs;
 }
 
-std::string BoltHumanoidDriver::get_error()
+std::optional<std::string> BoltHumanoidDriver::get_error()
 {
-    std::string error_msg = "";
-
-    auto board_errors_mat = bolthumanoid_.get_motor_board_errors();
-    // copy Eigen matrix to std::vector
-    std::vector<int> board_errors(
-        board_errors_mat.data(),
-        board_errors_mat.data() + board_errors_mat.size());
-
     if (bolthumanoid_.has_error())
     {
+        std::string error_msg = "";
+
+        auto board_errors_mat = bolthumanoid_.get_motor_board_errors();
+        // copy Eigen matrix to std::vector
+        std::vector<int> board_errors(
+            board_errors_mat.data(),
+            board_errors_mat.data() + board_errors_mat.size());
+
         for (auto error_code : boost::adaptors::index(board_errors))
         {
             if (error_code.value() != 0)
@@ -158,13 +158,15 @@ std::string BoltHumanoidDriver::get_error()
         {
             error_msg += "Unknown Error";
         }
+
+        return error_msg;
     }
 
     // TODO
     // Some errors on the master board are not reported but simply result in a
     // motor to be disabled.  So check for this explicitly.
 
-    return error_msg;
+    return std::nullopt;
 }
 
 void BoltHumanoidDriver::shutdown()
@@ -246,9 +248,9 @@ FakeBoltHumanoidDriver::get_latest_observation()
     return obs;
 }
 
-std::string FakeBoltHumanoidDriver::get_error()
+std::optional<std::string> FakeBoltHumanoidDriver::get_error()
 {
-    return "";
+    return std::nullopt;
 }
 
 void FakeBoltHumanoidDriver::shutdown()

--- a/src/bolthumanoid_pybullet_driver.cpp
+++ b/src/bolthumanoid_pybullet_driver.cpp
@@ -148,9 +148,9 @@ BoltHumanoidAction PyBulletBoltHumanoidDriver::apply_action(
     return desired_action;
 }
 
-std::string PyBulletBoltHumanoidDriver::get_error()
+std::optional<std::string> PyBulletBoltHumanoidDriver::get_error()
 {
-    return "";  // no errors
+    return std::nullopt;  // no errors
 }
 
 void PyBulletBoltHumanoidDriver::shutdown()


### PR DESCRIPTION
## Description
This is to keep up with a change in robot_interfaces (to be released in version 2.0).